### PR TITLE
Enable native windows support

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -51,6 +51,10 @@ rather than editing the core script. See
 [docs/SKILL_DISTRIBUTION.md](docs/SKILL_DISTRIBUTION.md) for profile fields,
 validation rules, and CI reproduction steps.
 
+## Windows VM Parity Testing
+
+See [Windows VM Contributing Guide](/docs/WINDOWS_VM_CONTRIBUTING.md) for details on end user parity testing for a Windows VM.
+
 ## Repository Layout
 
 ```

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -51,10 +51,6 @@ rather than editing the core script. See
 [docs/SKILL_DISTRIBUTION.md](docs/SKILL_DISTRIBUTION.md) for profile fields,
 validation rules, and CI reproduction steps.
 
-## Windows VM Parity Testing
-
-See [Windows VM Contributing Guide](/docs/WINDOWS_VM_CONTRIBUTING.md) for details on end user parity testing for a Windows VM.
-
 ## Repository Layout
 
 ```
@@ -424,6 +420,10 @@ marks the artifact as the implementation target, validation also checks:
 - Feature branches: `00N-<spec-name>` (e.g., `003-rh-inf-discovery`)
 - Commit trailer: `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>`
 - All tests must pass before merging; skill tests must have zero FAIL-level findings
+
+## Windows VM Parity Testing
+
+See [Windows VM Contributing Guide](docs/WINDOWS_VM_CONTRIBUTING.md) for details on end user parity testing for a Windows VM.
 
 ## Further Reading
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ understanding time lags in translational research." *J R Soc Med.* 2011;104(12):
 - [Usage Modes](docs/USAGE_MODES.md): CLI-first vs agent-native usage and configuration guidance
 - [Commands](docs/COMMANDS.md): full CLI reference with commands, subcommands, and options
 - [Example Project](example-project/): sample repository showing the expected project layout and artifacts
+- [Windows Installation](docs/WINDOWS_PYTHON_INSTALLATION.md): end user workflow for Python and RH Skills installation
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -112,22 +112,6 @@ repo_root = "/path/to/repo"
 Supported precedence is: **environment variables > local `.rh-skills.toml` >
 global `~/.rh-skills.toml`**.
 
-### Troubleshooting: `rh-skills: command not found`
-
-If the command isn't found after install, pipx's bin directory likely isn't on your `PATH`. Fix it with:
-
-```
-pipx ensurepath
-```
-
-Then **open a new terminal** (PATH changes don't apply to your current session) and try again.
-
-```
-source ~/.zshrc
-```
-
-**Windows users:**  After running `pipx ensurepath`, close and reopen your terminal entirely — not just the tab. VS Code users may need to restart VS Code itself for its integrated terminal to pick up the new PATH.
-
 ## Usage Modes
 
 The framework supports two modes — both use the `rh-skills` CLI for

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ artifacts will contain placeholder text rather than validated codes.
 {
   "mcpServers": {
     "reasonhub": {
-      "url": "https://mcp.reasonhub.app/mcp",
+      "url": "https://reasonhub.app/mcp",
       "headers": {
         "Authorization": "Bearer <your-api-key>"
       }
@@ -111,6 +111,22 @@ repo_root = "/path/to/repo"
 
 Supported precedence is: **environment variables > local `.rh-skills.toml` >
 global `~/.rh-skills.toml`**.
+
+### Troubleshooting: `rh-skills: command not found`
+
+If the command isn't found after install, pipx's bin directory likely isn't on your `PATH`. Fix it with:
+
+```
+pipx ensurepath
+```
+
+Then **open a new terminal** (PATH changes don't apply to your current session) and try again.
+
+```
+source ~/.zshrc
+```
+
+**Windows users:**  After running `pipx ensurepath`, close and reopen your terminal entirely — not just the tab. VS Code users may need to restart VS Code itself for its integrated terminal to pick up the new PATH.
 
 ## Usage Modes
 

--- a/docs/WINDOWS_PYTHON_INSTALLATION.md
+++ b/docs/WINDOWS_PYTHON_INSTALLATION.md
@@ -1,0 +1,90 @@
+# Windows Setup Guide for Python CLI Tools
+
+The simplest Windows setup for Python CLI tools:
+
+1. Install Python from the official Windows installer
+2. Install pipx
+3. Install Git
+4. Use pipx to install each CLI globally for that user
+
+pipx keeps each tool isolated in its own virtual environment while exposing a normal command on PATH. pipx requires Python 3.9+.
+
+## 1) Install Python
+
+Download and run the official Python for Windows installer from [python.org](https://www.python.org/downloads/windows/).
+
+During installation, check **"Add python.exe to PATH"**.
+
+After installation, verify in PowerShell:
+
+```powershell
+py --version
+```
+
+or
+
+```powershell
+python --version
+```
+
+On Windows, `py` is often the safest command to use because it avoids some PATH confusion.
+
+## 2) Install pipx
+
+In PowerShell:
+
+```powershell
+py -m pip install --user pipx
+py -m pipx ensurepath
+```
+
+Then **close and reopen the terminal**. The `ensurepath` step updates PATH so pipx-installed apps can be run directly.
+
+If `py` is not available but `python` is:
+
+```powershell
+python -m pip install --user pipx
+python -m pipx ensurepath
+```
+
+Verify:
+
+```powershell
+pipx --version
+```
+
+## 3) Install Git
+
+pipx needs Git to install packages directly from GitHub repositories.
+
+Download and run the official installer from [git-scm.com](https://git-scm.com/download/win).
+
+The defaults are fine for most users. Make sure **"Git from the command line and also from 3rd-party software"** is selected so Git is added to PATH.
+
+Close and reopen the terminal, then verify:
+
+```powershell
+git --version
+```
+
+## 4) Install the CLI tool with pipx
+
+For a package published on GitHub:
+
+```powershell
+pipx install git+https://github.com/reason-healthcare/rh-skills.git
+```
+
+Verify it installed:
+
+```powershell
+pipx list
+```
+
+The CLI command should now be available directly in any new terminal window.
+
+## Troubleshooting
+
+- **`pipx: command not found`** — Close and reopen the terminal after `pipx ensurepath`. If still missing, run `py -m pipx ensurepath` again and check that `%USERPROFILE%\.local\bin` is in your PATH.
+- **`git: command not found` during pipx install** — Git isn't on PATH. Reinstall Git and select the command-line option, then reopen the terminal.
+- **Upgrading a tool later** — `pipx upgrade <package-name>` or `pipx reinstall <package-name>` for a fresh install from the same source.

--- a/docs/WINDOWS_PYTHON_INSTALLATION.md
+++ b/docs/WINDOWS_PYTHON_INSTALLATION.md
@@ -1,7 +1,5 @@
 # Windows Setup Guide for Python CLI Tools
 
-The simplest Windows setup for Python CLI tools:
-
 1. Install Python from the official Windows installer
 2. Install pipx
 3. Install Git

--- a/docs/WINDOWS_PYTHON_INSTALLATION.md
+++ b/docs/WINDOWS_PYTHON_INSTALLATION.md
@@ -7,11 +7,9 @@ The simplest Windows setup for Python CLI tools:
 3. Install Git
 4. Use pipx to install each CLI globally for that user
 
-pipx keeps each tool isolated in its own virtual environment while exposing a normal command on PATH. pipx requires Python 3.9+.
-
 ## 1) Install Python
 
-Download and run the official Python for Windows installer from [python.org](https://www.python.org/downloads/windows/).
+Python 3.13+ is required. Download and run the official Python 3.13 or newer Windows installer from [python.org](https://www.python.org/downloads/windows/).
 
 During installation, check **"Add python.exe to PATH"**.
 
@@ -30,6 +28,8 @@ python --version
 On Windows, `py` is often the safest command to use because it avoids some PATH confusion.
 
 ## 2) Install pipx
+
+Pipx keeps each tool isolated in its own virtual environment while exposing a normal command on PATH.
 
 In PowerShell:
 
@@ -55,7 +55,7 @@ pipx --version
 
 ## 3) Install Git
 
-pipx needs Git to install packages directly from GitHub repositories.
+Pipx needs Git to install packages directly from GitHub repositories.
 
 Download and run the official installer from [git-scm.com](https://git-scm.com/download/win).
 

--- a/docs/WINDOWS_VM_CONTRIBUTING.md
+++ b/docs/WINDOWS_VM_CONTRIBUTING.md
@@ -1,0 +1,87 @@
+# Windows VM Contributing Guide
+
+This guide is for contributors validating Windows behavior while developing on a
+non-Windows host (for example, macOS + Windows VM).
+
+Use this when you need to verify end-user install parity from current source
+changes before merge/release.
+
+## Goal
+
+Validate both of these paths in the VM:
+
+1. Local source parity install: `pipx install --force .`
+2. End-user install path: `pipx install --force "git+https://github.com/reason-healthcare/rh-skills.git"`
+
+## Prerequisites
+
+Before running the parity workflow, confirm:
+
+1. Windows VM PowerShell session is active.
+2. Python 3.13+ is available (`py --version` or `python --version`).
+3. `pipx` is installed and on PATH (`pipx --version`).
+4. Git is installed and on PATH (`git --version`).
+5. You are in the repo root (or your mounted repo path exists) and it contains
+	`pyproject.toml`.
+6. Network access to GitHub is available for `git+https` install tests.
+
+Helpful pre-checks:
+
+```powershell
+Get-Location
+Test-Path ".\pyproject.toml"
+
+# If using an explicit mounted path instead:
+Test-Path "<mounted-repo-path>"
+Test-Path "<mounted-repo-path>\pyproject.toml"
+```
+
+## 1) Confirm command source
+
+Before installing, check which launcher PowerShell resolves:
+
+```powershell
+where rh-skills
+Get-Command rh-skills | Format-List Source,Definition
+```
+
+If this points to a stale or host-linked launcher, ignore/remove it for parity
+testing.
+
+## 2) Install from mounted local source
+
+From the mounted repo root:
+
+```powershell
+Set-Location "<mounted-repo-path>"
+pipx uninstall rh-skills
+pipx install --force .
+```
+
+Smoke check:
+
+```powershell
+pipx run --spec rh-skills python -c "import rh_skills, rh_skills.commands, jinja2; print('ok')"
+rh-skills --help
+```
+
+## 3) Verify end-user GitHub install path
+
+```powershell
+pipx uninstall rh-skills
+pipx install --force "git+https://github.com/reason-healthcare/rh-skills.git"
+rh-skills --help
+```
+
+If local source install passes but GitHub install fails, investigate branch,
+commit, or source selection differences.
+
+## 4) Optional wheel parity check
+
+If you built a wheel from the host:
+
+```powershell
+pipx uninstall rh-skills
+pipx install --force "<mounted-repo-path>\\dist\\rh_skills-0.1.0-py3-none-any.whl"
+rh-skills --help
+```

--- a/docs/WINDOWS_VM_CONTRIBUTING.md
+++ b/docs/WINDOWS_VM_CONTRIBUTING.md
@@ -21,9 +21,10 @@ Before running the parity workflow, confirm:
 2. Python 3.13+ is available (`py --version` or `python --version`).
 3. `pipx` is installed and on PATH (`pipx --version`).
 4. Git is installed and on PATH (`git --version`).
-5. You are in the repo root (or your mounted repo path exists) and it contains
-	`pyproject.toml`.
+5. You are in the repo root (or your mounted repo path exists) and it contains `pyproject.toml`.
 6. Network access to GitHub is available for `git+https` install tests.
+
+See [Windows Python Installation](./WINDOWS_PYTHON_INSTALLATION.md) for installation on Windows.
 
 Helpful pre-checks:
 

--- a/src/rh_skills/commands/promote.py
+++ b/src/rh_skills/commands/promote.py
@@ -12,6 +12,7 @@ from ruamel.yaml import YAML
 from rh_skills.common import (
     append_topic_event,
     config_value,
+    lock_file,
     log_info,
     log_warn,
     now_iso,
@@ -22,6 +23,7 @@ from rh_skills.common import (
     sources_root,
     today_date,
     topic_dir,
+    unlock_file,
 )
 from rh_skills.commands.validate import validate_artifact_file
 
@@ -863,10 +865,10 @@ def _lock_plan(plan_path: Path):
     lock_path = plan_path.with_suffix(".lock")
     lock_fd = lock_path.open("w")
     try:
-        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        lock_file(lock_fd)
         yield
     finally:
-        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        unlock_file(lock_fd)
         lock_fd.close()
 
 

--- a/src/rh_skills/commands/promote.py
+++ b/src/rh_skills/commands/promote.py
@@ -1,6 +1,5 @@
 """rh-skills promote — Promote artifacts between lifecycle levels."""
 
-import fcntl
 import io
 import sys
 from contextlib import contextmanager

--- a/src/rh_skills/common.py
+++ b/src/rh_skills/common.py
@@ -1,9 +1,9 @@
 """Shared utilities for the rh-skills CLI."""
 
 import contextlib
-import fcntl
 import hashlib
 import os
+import sys
 import tempfile
 import tomllib
 from datetime import datetime, timezone
@@ -12,6 +12,24 @@ from pathlib import Path
 from ruamel.yaml import YAML
 
 import click
+
+
+if sys.platform == "win32":
+    import msvcrt
+
+    def lock_file(f) -> None:
+        msvcrt.locking(f.fileno(), msvcrt.LK_LOCK, 1)
+
+    def unlock_file(f) -> None:
+        msvcrt.locking(f.fileno(), msvcrt.LK_UNLCK, 1)
+else:
+    import fcntl
+
+    def lock_file(f) -> None:
+        fcntl.flock(f, fcntl.LOCK_EX)
+
+    def unlock_file(f) -> None:
+        fcntl.flock(f, fcntl.LOCK_UN)
 
 
 _CONFIG_KEYS = {
@@ -223,11 +241,11 @@ def _tracking_lock():
     lock_path = tracking_file().with_suffix(".lock")
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     with open(lock_path, "w") as lf:
-        fcntl.flock(lf, fcntl.LOCK_EX)
+        lock_file(lf)
         try:
             yield
         finally:
-            fcntl.flock(lf, fcntl.LOCK_UN)
+            unlock_file(lf)
 
 
 def locked_update_tracking(fn) -> None:


### PR DESCRIPTION
1) Enable native Windows support for CLI (rh-skills CLI now works in powershell without WSL)
2) Add setup instructions for Windows
3) Fix MCP URL in `README.md`: https://mcp.reasonhub.app/mcp - > https://reasonhub.app/mcp